### PR TITLE
Added supported for API documentation fetching and expansion

### DIFF
--- a/.build/VersionAssemblyInfo.cs
+++ b/.build/VersionAssemblyInfo.cs
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyVersion("0.5.0.0")] 
-[assembly: System.Reflection.AssemblyFileVersion("0.5.0.0")] 
-[assembly: System.Reflection.AssemblyInformationalVersion("0.5.0.0")] 
+[assembly: System.Reflection.AssemblyVersion("0.6.0.0")] 
+[assembly: System.Reflection.AssemblyFileVersion("0.6.0.0")] 
+[assembly: System.Reflection.AssemblyInformationalVersion("0.6.0.0")] 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2243:AttributeStringLiteralsShouldParseCorrectly", Justification = "Commit hash added to AssemblyInformationalVersion is on purpose.")] 

--- a/Heracles.net.Tests/Given_instance_of/ApiDocumentationExtendingGraphTransformer_class/when_transforming.cs
+++ b/Heracles.net.Tests/Given_instance_of/ApiDocumentationExtendingGraphTransformer_class/when_transforming.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Heracles;
+using Heracles.DataModel;
+using Heracles.Namespaces;
+using Heracles.Rdf.GraphTransformations;
+using Heracles.Testing;
+using Moq;
+using NUnit.Framework;
+using RDeF.Entities;
+using RollerCaster;
+
+namespace Given_instance_of.ApiDocumentationExtendingGraphTransformer_class
+{
+    [TestFixture]
+    public class when_transforming
+    {
+        private ApiDocumentationExtendingGraphTransformer Transformer { get; set; }
+        
+        private IResource Resource { get; set; }
+        
+        private Mock<IHypermediaProcessor> Processor { get; set; }
+        
+        private Mock<IHypermediaProcessingOptions> Options { get; set; }
+        
+        private IEnumerable<ITypedEntity> Result { get; set; }
+        
+        [SetUp]
+        public void Setup()
+        {
+            Processor = new Mock<IHypermediaProcessor>(MockBehavior.Strict);
+            var context = Mappings.InContextOf(hydra.Collection);
+            var operation = new MulticastObject();
+            context.Setup(_ => _.Create<IOperation>(It.IsAny<Iri>())).Returns(operation.ActLike<IOperation>());
+            var supportedOperation = new Mock<IOperation>();
+            supportedOperation.SetupGet(_ => _.Title).Returns("title");
+            supportedOperation.SetupGet(_ => _.Context).Returns(context.Object);
+            var supportedClass = new Mock<IClass>(MockBehavior.Strict);
+            supportedClass.SetupGet(_ => _.Iri).Returns(hydra.Collection);
+            supportedClass.SetupGet(_ => _.SupportedOperations)
+                .Returns(new HashSet<IOperation>() { supportedOperation.Object });
+            var apiDocumentation = new Mock<IApiDocumentation>(MockBehavior.Strict);
+            apiDocumentation.SetupGet(_ => _.SupportedClasses).Returns(new HashSet<IClass>() { supportedClass.Object });
+            Options = new Mock<IHypermediaProcessingOptions>(MockBehavior.Strict);
+            Options.SetupGet(_ => _.ApiDocumentations).Returns(new[] { apiDocumentation.Object });
+            Options.SetupGet(_ => _.OriginalUrl).Returns(new Uri("http://temp.uri/"));
+            var proxy = new MulticastObject();
+            proxy.SetProperty(typeof(IEntity).GetProperty(nameof(IEntity.Context)), context.Object);
+            Resource = proxy.ActLike<IResource>();
+            Resource.Type.Add(hydra.Collection);
+            Transformer = new ApiDocumentationExtendingGraphTransformer();
+            TheTest();
+        }
+
+        public void TheTest()
+        {
+            Result = Transformer.Transform(new[] { Resource }, Processor.Object, Options.Object);
+        }
+
+        [Test]
+        public void should_add_API_documentation_discovered_operation()
+        {
+            Result.Should().Contain(Resource).Which.ActLike<IHydraResource>().Operations
+                .Should().HaveCount(1).And.Subject.First().Title.Should().Be("title");
+        }
+    }
+}

--- a/Heracles.net.Tests/Given_instance_of/CompoundGraphTransformer_class/when_transforming.cs
+++ b/Heracles.net.Tests/Given_instance_of/CompoundGraphTransformer_class/when_transforming.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+using FluentAssertions;
+using Heracles;
+using Heracles.DataModel;
+using Heracles.Rdf.GraphTransformations;
+using Moq;
+using NUnit.Framework;
+using RDeF.Entities;
+
+namespace Given_instance_of.CompoundGraphTransformer_class
+{
+    [TestFixture]
+    public class when_transforming
+    {
+        private Mock<IResource> Resource { get; set; }
+        
+        private Mock<IHypermediaProcessor> Processor { get; set; }
+        
+        private Mock<IGraphTransformer> PrimaryGraphTransformer { get; set; }
+        
+        private Mock<IGraphTransformer> SecondaryGraphTransformer { get; set; }
+        
+        private CompoundGraphTransformer Transformer { get; set; }
+        
+        private IEnumerable<ITypedEntity> Result { get; set; }
+
+        [SetUp]
+        public void Setup()
+        {
+            Resource = new Mock<IResource>(MockBehavior.Strict);
+            Processor = new Mock<IHypermediaProcessor>(MockBehavior.Strict);
+            PrimaryGraphTransformer = new Mock<IGraphTransformer>(MockBehavior.Strict);
+            PrimaryGraphTransformer.Setup(
+                    _ => _.Transform(
+                        It.IsAny<IEnumerable<ITypedEntity>>(),
+                        It.IsAny<IHypermediaProcessor>(),
+                        It.IsAny<HypermediaProcessingOptions>()))
+                .Returns<IEnumerable<ITypedEntity>, IHypermediaProcessor, HypermediaProcessingOptions>(
+                    (resources, processor, options) => resources);
+            SecondaryGraphTransformer = new Mock<IGraphTransformer>(MockBehavior.Strict);
+            SecondaryGraphTransformer.Setup(
+                    _ => _.Transform(
+                        It.IsAny<IEnumerable<ITypedEntity>>(),
+                        It.IsAny<IHypermediaProcessor>(),
+                        It.IsAny<HypermediaProcessingOptions>()))
+                .Returns<IEnumerable<ITypedEntity>, IHypermediaProcessor, HypermediaProcessingOptions>(
+                    (resources, processor, options) => resources);
+            Transformer = new CompoundGraphTransformer(
+                new[] { PrimaryGraphTransformer.Object, SecondaryGraphTransformer.Object });
+            TheTest();
+        }
+
+        [Test]
+        public void TheTest()
+        {
+            Result = Transformer.Transform(new[] { Resource.Object }, Processor.Object);
+        }
+
+        [Test]
+        public void should_call_all_underlying_graph_transformers()
+        {
+            PrimaryGraphTransformer.Verify(
+                _ => _.Transform(
+                    It.Is<IEnumerable<ITypedEntity>>(resources => resources.First() == Resource.Object),
+                    Processor.Object,
+                    null),
+                Times.Once);
+           
+            SecondaryGraphTransformer.Verify(
+                _ => _.Transform(
+                    It.Is<IEnumerable<ITypedEntity>>(resources => resources.First() == Resource.Object),
+                    Processor.Object,
+                    null),
+                Times.Once);
+        }
+
+        [Test]
+        public void should_provide_resulting_resources()
+        {
+            Result.Should().BeEquivalentTo(Resource.Object);
+        }
+    }
+}

--- a/Heracles.net.Tests/Given_instance_of/EntryPointCorrectingGraphTransformer_class/when_transforming.cs
+++ b/Heracles.net.Tests/Given_instance_of/EntryPointCorrectingGraphTransformer_class/when_transforming.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Heracles;
+using Heracles.DataModel;
+using Heracles.Namespaces;
+using Heracles.Rdf.GraphTransformations;
+using Heracles.Testing;
+using Moq;
+using Moq.Language.Flow;
+using NUnit.Framework;
+using RDeF.Entities;
+using RDeF.Mapping;
+using RollerCaster;
+using Tavis.UriTemplates;
+
+namespace Given_instance_of.EntryPointCorrectingGraphTransformer_class
+{
+    [TestFixture]
+    public class when_transforming
+    {
+        private EntryPointCorrectingGraphTransformer Transformer { get; set; }
+        
+        private Mock<IHypermediaProcessingOptions> Options { get; set; }
+        
+        private Mock<IResponse> EntryPoint { get; set; }
+        
+        private Mock<IHypermediaProcessor> Processor { get; set; }
+        
+        private IApiDocumentation ApiDocumentation { get; set; }
+        
+        private IEnumerable<ITypedEntity> Result { get; set; }
+        
+        [SetUp]
+        public void Setup()
+        {
+            Mappings.For<IApiDocumentation>();
+            Transformer = new EntryPointCorrectingGraphTransformer();
+            Options = new Mock<IHypermediaProcessingOptions>(MockBehavior.Strict);
+            EntryPoint = new Mock<IResponse>(MockBehavior.Strict);
+            Options.SetupGet(_ => _.AuxiliaryOriginalUrl).Returns(new Uri("http://temp.uri/"));
+            Options.SetupGet(_ => _.AuxiliaryResponse).Returns(EntryPoint.Object);
+            Processor = new Mock<IHypermediaProcessor>(MockBehavior.Strict);
+            Processor.Setup(_ => _.Supports(It.IsAny<IResponse>())).Returns(Level.FullSupport);
+            var context = Mappings.InContextOf(hydra.ApiDocumentation);
+            var entryPoint = new MulticastObject();
+            entryPoint.SetProperty(typeof(IEntity).GetProperty(nameof(IEntity.Iri)), new Iri("http://temp.uri/"));
+            context.Setup(_ => _.Create<IResource>(It.IsAny<Iri>())).Returns(entryPoint.ActLike<IResource>());
+            var proxy = new MulticastObject();
+            proxy.SetProperty(typeof(IEntity).GetProperty(nameof(IEntity.Context)), context.Object);
+            ApiDocumentation = proxy.ActLike<IApiDocumentation>();
+            ApiDocumentation.Type.Add(hydra.ApiDocumentation);
+            TheTest();
+        }
+
+        public void TheTest()
+        {
+            Result = Transformer.Transform(new[] { ApiDocumentation }, Processor.Object, Options.Object);
+        }
+
+        [Test]
+        public void should_check_processor_supports_the_initial_request()
+        {
+            Processor.Verify(_ => _.Supports(EntryPoint.Object), Times.Once);
+        }
+
+        [Test]
+        public void should_setup_an_entrypoint()
+        {
+            ApiDocumentation.EntryPoint.Should().BeAssignableTo<IResource>()
+                .Which.Iri.Should().Be(new Iri("http://temp.uri/"));
+        }
+    }
+}

--- a/Heracles.net.Tests/Given_instance_of/HydraClientFactory_class.cs
+++ b/Heracles.net.Tests/Given_instance_of/HydraClientFactory_class.cs
@@ -50,6 +50,27 @@ namespace Given_instance_of
         }
 
         [Test]
+        public void should_create_a_client_fetching_no_API_documentations()
+        {
+            Factory.WithNoApiDocumentations().AndCreate().Should().BeOfType<HydraClient>()
+                .Which.ApiDocumentationPolicy.Should().Be(ApiDocumentationPolicy.None);
+        }
+
+        [Test]
+        public void should_create_a_client_fetching_API_documentations()
+        {
+            Factory.WithApiDocumentationsFetchedOnly().AndCreate().Should().BeOfType<HydraClient>()
+                .Which.ApiDocumentationPolicy.Should().Be(ApiDocumentationPolicy.FetchOnly);
+        }
+
+        [Test]
+        public void should_create_a_client_fetching_and_extending_API_documentations()
+        {
+            Factory.WithApiDocumentationsFetchedAndExtended().AndCreate().Should().BeOfType<HydraClient>()
+                .Which.ApiDocumentationPolicy.Should().Be(ApiDocumentationPolicy.FetchAndExtend);
+        }
+
+        [Test]
         public void should_create_a_client_with_custom_hypermedia_processor()
         {
             Factory.With(Processor.Object).AndCreate().GetHypermediaProcessor(Response.Object)

--- a/Heracles.net.Tests/Given_instance_of/HydraClient_class/HydraClientTest.cs
+++ b/Heracles.net.Tests/Given_instance_of/HydraClient_class/HydraClientTest.cs
@@ -20,6 +20,8 @@ namespace Given_instance_of.HydraClient_class
         protected Mock<IIriTemplateExpansionStrategy> IriTemplateExpansionStrategy { get; private set; }
 
         protected Mock<IHttpInfrastructure> HttpCall { get; private set; }
+        
+        protected Mock<IResourceCache> Cache { get; private set; }
 
         protected HydraClient Client { get; private set; }
 
@@ -44,11 +46,14 @@ namespace Given_instance_of.HydraClient_class
             HttpCall = new Mock<IHttpInfrastructure>(MockBehavior.Strict);
             HttpCall.Setup(_ => _.HttpCall(It.IsAny<Uri>(), It.IsAny<IHttpOptions>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Return.Ok());
+            Cache = new Mock<IResourceCache>(MockBehavior.Strict);
             Client = new HydraClient(
                 new[] { HypermediaProcessor.Object },
                 IriTemplateExpansionStrategy.Object,
                 LinksPolicy.Strict,
-                HttpCall.Object.HttpCall);
+                ApiDocumentationPolicy.None,
+                HttpCall.Object.HttpCall,
+                Cache.Object);
             ScenarioSetup();
             await TheTest();
         }

--- a/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_fetching_a_resource/and_that_resource_was_provided_correctly.cs
+++ b/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_fetching_a_resource/and_that_resource_was_provided_correctly.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -32,8 +33,10 @@ namespace Given_instance_of.HydraClient_class.when_fetching_a_resource
                 .Setup(_ => _.Process(
                     It.IsAny<IResponse>(),
                     It.IsAny<IHydraClient>(),
-                    It.IsAny<IHypermediaProcessingOptions>()))
+                    It.IsAny<IHypermediaProcessingOptions>(),
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Resource.Object);
+            Cache.Setup(_ => _.All<IApiDocumentation>()).Returns(Array.Empty<IApiDocumentation>());
         }
         
         public override async Task TheTest()
@@ -45,7 +48,11 @@ namespace Given_instance_of.HydraClient_class.when_fetching_a_resource
         public void should_process_the_response()
         {
             HypermediaProcessor.Verify(
-                _ => _.Process(ResourceResponse, Client, It.IsAny<IHypermediaProcessingOptions>()),
+                _ => _.Process(
+                    ResourceResponse,
+                    Client,
+                    It.IsAny<IHypermediaProcessingOptions>(),
+                    CancellationToken.None),
                 Times.Once);
         }
 
@@ -53,6 +60,12 @@ namespace Given_instance_of.HydraClient_class.when_fetching_a_resource
         public void should_return_a_correct_result()
         {
             Result.As<object>().Should().Be(Resource.Object);
+        }
+
+        [Test]
+        public void should_obtain_all_cached_API_documentations()
+        {
+            Cache.Verify(_ => _.All<IApiDocumentation>(), Times.Once);
         }
     }
 }

--- a/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/ScenarioTest.cs
+++ b/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/ScenarioTest.cs
@@ -1,0 +1,15 @@
+using System;
+using Heracles.DataModel;
+using Moq;
+
+namespace Given_instance_of.HydraClient_class.when_obtaining_an_API_documentation
+{
+    public class ScenarioTest : HydraClientTest
+    {
+        public override void ScenarioSetup()
+        {
+            base.ScenarioSetup();
+            Cache.SetupGet(_ => _[It.IsAny<Uri>()]).Returns((IResource)null);
+        }
+    }
+}

--- a/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/from_a_valid_site/ScenarioTest.cs
+++ b/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/from_a_valid_site/ScenarioTest.cs
@@ -7,7 +7,7 @@ using Moq;
 
 namespace Given_instance_of.HydraClient_class.when_obtaining_an_API_documentation.from_a_valid_site
 {
-    public abstract class ScenarioTest : HydraClientTest
+    public abstract class ScenarioTest : when_obtaining_an_API_documentation.ScenarioTest
     {
         protected IResponse UrlResponse { get; private set; }
 

--- a/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/from_a_valid_site/and_that_documentation_has_no_entry_point_provided.cs
+++ b/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/from_a_valid_site/and_that_documentation_has_no_entry_point_provided.cs
@@ -21,8 +21,13 @@ namespace Given_instance_of.HydraClient_class.when_obtaining_an_API_documentatio
             HttpCall.Setup(_ => _.HttpCall(new Uri(BaseUrl, "api/documentation"), It.IsAny<IHttpOptions>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Return.Ok());
             HypermediaProcessor
-                .Setup(_ => _.Process(It.IsAny<IResponse>(), It.IsAny<IHydraClient>(), It.IsAny<IHypermediaProcessingOptions>()))
+                .Setup(_ => _.Process(
+                    It.IsAny<IResponse>(),
+                    It.IsAny<IHydraClient>(),
+                    It.IsAny<IHypermediaProcessingOptions>(),
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(hypermedia.Object);
+            Cache.Setup(_ => _.All<IApiDocumentation>()).Returns(Array.Empty<IApiDocumentation>());
         }
 
         [Test]

--- a/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/from_a_valid_site/which_is_provided_correctly.cs
+++ b/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/from_a_valid_site/which_is_provided_correctly.cs
@@ -18,22 +18,30 @@ namespace Given_instance_of.HydraClient_class.when_obtaining_an_API_documentatio
         private IResponse Response { get; set; }
 
         private Uri ApiDocumentationUrl { get; set; }
+        
+        private Mock<IApiDocumentation> ApiDocumentation { get; set; }
 
         public override void ScenarioSetup()
         {
             base.ScenarioSetup();
             ApiDocumentationUrl = new Uri(BaseUrl, "api/documentation");
-            var apiDocumentation = new Mock<IApiDocumentation>(MockBehavior.Strict);
-            apiDocumentation.SetupGet(_ => _.EntryPoint).Returns(Resource.Of<IResource>(new Uri(BaseUrl, "api")).Object);
-            apiDocumentation.SetupGet(_ => _.Type).Returns(new HashSet<Iri>() { hydra.ApiDocumentation });
+            ApiDocumentation = new Mock<IApiDocumentation>(MockBehavior.Strict);
+            ApiDocumentation.SetupGet(_ => _.EntryPoint).Returns(Resource.Of<IResource>(new Uri(BaseUrl, "api")).Object);
+            ApiDocumentation.SetupGet(_ => _.Type).Returns(new HashSet<Iri>() { hydra.ApiDocumentation });
             var hypermedia = new Mock<IHypermediaContainer>(MockBehavior.Strict);
             hypermedia.Setup(_ => _.GetEnumerator())
-                .Returns(new List<IResource>(new[] { apiDocumentation.Object }).GetEnumerator());
+                .Returns(new List<IResource>(new[] { ApiDocumentation.Object }).GetEnumerator());
             HttpCall.Setup(_ => _.HttpCall(ApiDocumentationUrl, It.IsAny<IHttpOptions>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Response = Return.Ok());
             HypermediaProcessor
-                .Setup(_ => _.Process(It.IsAny<IResponse>(), It.IsAny<IHydraClient>(), It.IsAny<IHypermediaProcessingOptions>()))
+                .Setup(_ => _.Process(
+                    It.IsAny<IResponse>(),
+                    It.IsAny<IHydraClient>(),
+                    It.IsAny<IHypermediaProcessingOptions>(),
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(hypermedia.Object);
+            Cache.Setup(_ => _.All<IApiDocumentation>()).Returns(Array.Empty<IApiDocumentation>());
+            Cache.SetupSet(_ => _[It.IsAny<Uri>()] = It.IsAny<IResource>());
         }
 
         public override async Task TheTest()
@@ -51,7 +59,7 @@ namespace Given_instance_of.HydraClient_class.when_obtaining_an_API_documentatio
         public void should_fetch_the_API_documentation()
         {
             HttpCall.Verify(
-                _ => _.HttpCall(new Uri(BaseUrl, "api/documentation"), It.IsAny<IHttpOptions>(), It.IsAny<CancellationToken>()),
+                _ => _.HttpCall(ApiDocumentationUrl, It.IsAny<IHttpOptions>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
                 
@@ -66,8 +74,27 @@ namespace Given_instance_of.HydraClient_class.when_obtaining_an_API_documentatio
                         options.AuxiliaryOriginalUrl == BaseUrl
                         && options.AuxiliaryResponse == UrlResponse
                         && options.LinksPolicy == LinksPolicy.Strict
-                        && options.OriginalUrl == ApiDocumentationUrl)),
+                        && options.OriginalUrl == ApiDocumentationUrl),
+                    CancellationToken.None),
                 Times.Once);
+        }
+
+        [Test]
+        public void should_try_obtaining_an_API_documentation_from_cache()
+        {
+            Cache.VerifyGet(_ => _[ApiDocumentationUrl], Times.Once);
+        }
+
+        [Test]
+        public void should_store_obtained_API_documentation_in_cache()
+        {
+            Cache.VerifySet(_ => _[ApiDocumentationUrl] = ApiDocumentation.Object, Times.Once);
+        }
+
+        [Test]
+        public void should_obtain_all_cached_API_documentations_so_far()
+        {
+            Cache.Verify(_ => _.All<IApiDocumentation>(), Times.Once);
         }
     }
 }

--- a/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/of_which_sites_main_document_is_not_found.cs
+++ b/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/of_which_sites_main_document_is_not_found.cs
@@ -10,7 +10,7 @@ using NUnit.Framework;
 namespace Given_instance_of.HydraClient_class.when_obtaining_an_API_documentation
 {
     [TestFixture]
-    public class of_which_sites_main_document_is_not_found : HydraClientTest
+    public class of_which_sites_main_document_is_not_found : ScenarioTest
     {
         public override void ScenarioSetup()
         {

--- a/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/which_has_no_LINK_header_returned.cs
+++ b/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/which_has_no_LINK_header_returned.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace Given_instance_of.HydraClient_class.when_obtaining_an_API_documentation
 {
     [TestFixture]
-    public class which_has_no_LINK_header_returned : HydraClientTest
+    public class which_has_no_LINK_header_returned : ScenarioTest
     {
         [Test]
         public void should_throw()

--- a/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/which_is_not_provided_within_the_LINK_header.cs
+++ b/Heracles.net.Tests/Given_instance_of/HydraClient_class/when_obtaining_an_API_documentation/which_is_not_provided_within_the_LINK_header.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 namespace Given_instance_of.HydraClient_class.when_obtaining_an_API_documentation
 {
     [TestFixture]
-    public class which_is_not_provided_within_the_LINK_header : HydraClientTest
+    public class which_is_not_provided_within_the_LINK_header : ScenarioTest
     {
         public override void ScenarioSetup()
         {

--- a/Heracles.net.Tests/Given_instance_of/IApiDocumentation_interface/when_obtaining_an_entry_point.cs
+++ b/Heracles.net.Tests/Given_instance_of/IApiDocumentation_interface/when_obtaining_an_entry_point.cs
@@ -25,6 +25,7 @@ namespace Given_instance_of.IApiDocumentation_interface
         [SetUp]
         public async Task Setup()
         {
+            Mappings.For<IApiDocumentation>();
             EntryPoint = new Mock<IHypermediaContainer>(MockBehavior.Strict);
             Client = new Mock<IHydraClient>(MockBehavior.Strict);
             Client.Setup(_ => _.GetResource(It.IsAny<IResource>())).ReturnsAsync(EntryPoint.Object);

--- a/Heracles.net.Tests/Given_instance_of/JsonLdHypermediaProcessor_class/when_parsing/JSON_LD_response/with_collections.cs
+++ b/Heracles.net.Tests/Given_instance_of/JsonLdHypermediaProcessor_class/when_parsing/JSON_LD_response/with_collections.cs
@@ -19,11 +19,13 @@ namespace Given_instance_of.JsonLdHypermediaProcessor_class.when_parsing.JSON_LD
         {
             get { return _inputJsonLd; }
         }
+
+        protected override Uri Uri { get; } = new Uri("http://temp.uri/api", UriKind.Absolute);
         
         public override void ScenarioSetup()
         {
             _inputJsonLd = GetResourceNamed("collectionsInput.json");
-            Response.SetupGet(_ => _.Url).Returns(new Uri("http://temp.uri/api"));
+            Response.SetupGet(_ => _.Url).Returns(Uri);
             base.ScenarioSetup();
         }
 

--- a/Heracles.net.Tests/Given_instance_of/JsonLdHypermediaProcessor_class/when_parsing/JSON_LD_response/with_nested_resources.cs
+++ b/Heracles.net.Tests/Given_instance_of/JsonLdHypermediaProcessor_class/when_parsing/JSON_LD_response/with_nested_resources.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -20,6 +21,8 @@ namespace Given_instance_of.JsonLdHypermediaProcessor_class.when_parsing.JSON_LD
             get { return _inputJsonLd; }
         }
 
+        protected override Uri Uri { get; } = Api.People.Markus;
+
         private IHydraResource Markus { get; set; }
 
         private IHydraResource Karol { get; set; }
@@ -27,7 +30,7 @@ namespace Given_instance_of.JsonLdHypermediaProcessor_class.when_parsing.JSON_LD
         public override void ScenarioSetup()
         {
             _inputJsonLd = GetResourceNamed("nestedResourcesInput.json");
-            Response.SetupGet(_ => _.Url).Returns(Api.People.Markus);
+            Response.SetupGet(_ => _.Url).Returns(Uri);
             base.ScenarioSetup();
         }
 

--- a/Heracles.net.Tests/Given_instance_of/JsonLdHypermediaProcessor_class/when_parsing/JSON_LD_response/with_templated_operation.cs
+++ b/Heracles.net.Tests/Given_instance_of/JsonLdHypermediaProcessor_class/when_parsing/JSON_LD_response/with_templated_operation.cs
@@ -21,13 +21,15 @@ namespace Given_instance_of.JsonLdHypermediaProcessor_class.when_parsing.JSON_LD
         {
             get { return _inputJsonLd; }
         }
+        
+        protected override Uri Uri { get; } = new Uri("http://temp.uri/api/people", UriKind.Absolute);
 
         private IOperation AddPerson { get; set; }
         
         public override void ScenarioSetup()
         {
             _inputJsonLd = GetResourceNamed("operationInput.json");
-            Response.SetupGet(_ => _.Url).Returns(new Uri("http://temp.uri/api/people", UriKind.Absolute));
+            Response.SetupGet(_ => _.Url).Returns(Uri);
             base.ScenarioSetup();
         }
 

--- a/Heracles.net.Tests/Given_instance_of/JsonLdHypermediaProcessor_class/when_parsing/JSON_response.cs
+++ b/Heracles.net.Tests/Given_instance_of/JsonLdHypermediaProcessor_class/when_parsing/JSON_response.cs
@@ -13,6 +13,8 @@ namespace Given_instance_of.JsonLdHypermediaProcessor_class.when_parsing
     [TestFixture]
     public class JSON_response : JsonLdHypermediaProcessorTest
     {
+        protected override Uri Uri { get; } = new Uri("http://temp.uri/api", UriKind.Absolute);
+
         private Stream JsonLdContext { get; set; }
 
         public override void ScenarioSetup()
@@ -28,7 +30,7 @@ namespace Given_instance_of.JsonLdHypermediaProcessor_class.when_parsing
                 .Returns(new[] { "<context.jsonld>; rel=\"http://www.w3.org/ns/json-ld#context\"; type=\"application/ld+json\"" });
             var responseBody = new MemoryStream(Encoding.UTF8.GetBytes("{}"));
             responseBody.Seek(0, SeekOrigin.Begin);
-            Response.Setup(_ => _.Url).Returns(new Uri("http://temp.uri/api", UriKind.Absolute));
+            Response.Setup(_ => _.Url).Returns(Uri);
             Response.Setup(_ => _.GetBody(It.IsAny<CancellationToken>())).ReturnsAsync(responseBody);
         }
 

--- a/Heracles.net.Tests/Given_instance_of/SimpleVolatileResourceCache_class/when_operating.cs
+++ b/Heracles.net.Tests/Given_instance_of/SimpleVolatileResourceCache_class/when_operating.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Heracles;
+using Heracles.DataModel;
+using Moq;
+using NUnit.Framework;
+
+namespace Given_instance_of.SimpleVolatileResourceCache_class
+{
+    [TestFixture]
+    public class when_operating
+    {
+        private static readonly Uri Uri = new Uri("some:uri");
+        
+        private SimpleVolatileResourceCache Cache { get; set; }
+        
+        private Mock<IApiDocumentation> Resource { get; set; }
+        
+        [SetUp]
+        public void Setup()
+        {
+            Cache = new SimpleVolatileResourceCache();
+            Resource = new Mock<IApiDocumentation>(MockBehavior.Strict);
+            TheTest();
+        }
+
+        public void TheTest()
+        {
+            Cache[Uri] = Resource.Object;
+        }
+
+        [Test]
+        public void should_store_resource_within_cache()
+        {
+            Cache[Uri].Should().Be(Resource.Object);
+        }
+
+        [Test]
+        public void should_provide_all_resources_of_given_type()
+        {
+            Cache.All<IApiDocumentation>().Should().HaveCount(1).And.Subject.First().Should().Be(Resource.Object);
+        }
+    }
+}

--- a/Heracles.net.Tests/Given_instance_of/TemplatedLink_interface/when_expanding_URI_with_variable_values.cs
+++ b/Heracles.net.Tests/Given_instance_of/TemplatedLink_interface/when_expanding_URI_with_variable_values.cs
@@ -51,7 +51,7 @@ namespace Given_instance_of.TemplatedLink_interface
             proxy.SetProperty(typeof(IPointingResource).GetProperty(nameof(IPointingResource.BaseUrl)), new Uri("http://temp.uri/"));
             proxy.SetProperty(typeof(IPointingResource).GetProperty(nameof(IPointingResource.Target)), target.Object);
             proxy.SetProperty(typeof(IDereferencableLink).GetProperty(nameof(IDereferencableLink.Relation)), "test");
-            proxy.SetProperty(JsonLdHypermediaProcessor.IriTemplatePropertyInfo, Template.Object);
+            proxy.SetProperty(ResourceExtensions.IriTemplatePropertyInfo, Template.Object);
             proxy.SetProperty(typeof(IEntity).GetProperty(nameof(IEntity.Context)), context.Object);
             Link = proxy.ActLike<ITemplatedLink>();
             TheTest();

--- a/Heracles.net.Tests/Given_instance_of/TemplatedOperation_interface/when_expanding_URI_with_variable_values.cs
+++ b/Heracles.net.Tests/Given_instance_of/TemplatedOperation_interface/when_expanding_URI_with_variable_values.cs
@@ -58,7 +58,7 @@ namespace Given_instance_of.TemplatedOperation_interface
             var proxy = new MulticastObject();
             proxy.SetProperty(typeof(IPointingResource).GetProperty(nameof(IPointingResource.BaseUrl)), new Uri("http://temp.uri/"));
             proxy.SetProperty(typeof(IPointingResource).GetProperty(nameof(IPointingResource.Target)), target.Object);
-            proxy.SetProperty(JsonLdHypermediaProcessor.IriTemplatePropertyInfo, Template.Object);
+            proxy.SetProperty(ResourceExtensions.IriTemplatePropertyInfo, Template.Object);
             proxy.SetProperty(typeof(IEntity).GetProperty(nameof(IEntity.Context)), context.Object);
             Operation = proxy.ActLike<ITemplatedOperation>();
             Operation.Type.Add(AddAction);

--- a/Heracles.net.Tests/Having_a_Hydra_client/while_browsing_a_website/and_obtaining_its_API_documentation/ScenarioTest.cs
+++ b/Heracles.net.Tests/Having_a_Hydra_client/while_browsing_a_website/and_obtaining_its_API_documentation/ScenarioTest.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using Heracles.DataModel;
 using Heracles.DataModel.Collections;
 using Heracles.Namespaces;
@@ -37,13 +38,30 @@ namespace Having_a_Hydra_client.while_browsing_a_website.and_obtaining_its_API_d
                         Iri = new Iri("http://schema.org/Event"),
                         Links = new ILink[0],
                         Operations = new IOperation[0],
-                        SupportedOperations = new IOperation[0],
+                        SupportedOperations = new object[]
+                        {
+                            new
+                            {
+                                BaseUrl = new Uri("http://localhost:3001/api/documentation"),
+                                Collections = new ICollection[0],
+                                ExpectedHeaders = new string[0],
+                                Expects = new IResource[0],
+                                Iri = new Iri("_:b0"),
+                                Links = new ILink[0],
+                                Method = "DELETE",
+                                Operations = new IOperation[0],
+                                ReturnedHeaders = new string[0],
+                                Returns = new IResource[0],
+                                Target = new { Iri = new Iri("http://schema.org/Event"), Type = new[] { hydra.Class } },
+                                Type = new[] { hydra.Operation, new Iri("http://schema.org/DeleteAction") }
+                            }
+                        },
                         SupportedProperties = new object[]
                         {
                             new
                             {
                                 Collections = new ICollection[0],
-                                Iri = new Iri("_:b0"),
+                                Iri = new Iri("_:b1"),
                                 Links = new ILink[0],
                                 Operations = new IOperation[0],
                                 Property = new
@@ -62,7 +80,7 @@ namespace Having_a_Hydra_client.while_browsing_a_website.and_obtaining_its_API_d
                             new
                             {
                                 Collections = new ICollection[0],
-                                Iri = new Iri("_:b1"),
+                                Iri = new Iri("_:b2"),
                                 Links = new ILink[0],
                                 Operations = new IOperation[0],
                                 Property = new
@@ -81,7 +99,7 @@ namespace Having_a_Hydra_client.while_browsing_a_website.and_obtaining_its_API_d
                             new
                             {
                                 Collections = new ICollection[0],
-                                Iri = new Iri("_:b2"),
+                                Iri = new Iri("_:b3"),
                                 Links = new ILink[0],
                                 Operations = new IOperation[0],
                                 Property = new
@@ -104,7 +122,7 @@ namespace Having_a_Hydra_client.while_browsing_a_website.and_obtaining_its_API_d
                             new
                             {
                                 Collections = new ICollection[0],
-                                Iri = new Iri("_:b3"),
+                                Iri = new Iri("_:b4"),
                                 Links = new ILink[0],
                                 Operations = new IOperation[0],
                                 Property = new

--- a/Heracles.net.Tests/Having_a_Hydra_client/while_browsing_a_website/and_obtaining_its_entry_point/and_then_obtaining_events/and_then_requesting_some_specific_member.cs
+++ b/Heracles.net.Tests/Having_a_Hydra_client/while_browsing_a_website/and_obtaining_its_entry_point/and_then_obtaining_events/and_then_requesting_some_specific_member.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Heracles.DataModel;
+using Heracles.DataModel.Collections;
+using Heracles.Testing;
+using NUnit.Framework;
+using RDeF.Entities;
+
+namespace Having_a_Hydra_client.while_browsing_a_website.and_obtaining_its_entry_point.and_then_obtaining_events
+{
+    [TestFixture]
+    public class and_then_requesting_some_specific_member : ScenarioTest
+    {
+        private IHypermediaContainer Member { get; set; }
+
+        public override async Task TheTest()
+        {
+            await base.TheTest();
+            Member = await Client.GetResource(Events.Members.First());
+        }
+
+        [Test]
+        public void should_have_DELETE_operation_available()
+        {
+            Member.Operations.OfType(new Iri("http://schema.org/DeleteAction")).FirstOrDefault().Should().NotBeNull();
+        }
+
+        [Test]
+        public void should_have_DELETE_operation_applicable()
+        {
+            Member.Operations.OfType(new Iri("http://schema.org/DeleteAction")).First().Target.Iri
+                .Should().Be(Events.Members.First().Iri);
+        }
+    }
+}

--- a/Heracles.net.Tests/Heracles.net.Tests.csproj
+++ b/Heracles.net.Tests/Heracles.net.Tests.csproj
@@ -16,6 +16,9 @@
         <None Remove="Given_instance_of\JsonLdHypermediaProcessor_class\when_parsing\input.json" />
         <None Remove="Given_instance_of\JsonLdHypermediaProcessor_class\when_parsing\nestedResourcesInput.json" />
         <None Remove="Given_instance_of\JsonLdHypermediaProcessor_class\when_parsing\operationInput.json" />
+        <None Update="Server\api\events\1.jsonld">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 
     <ItemGroup>
@@ -33,8 +36,8 @@
         <PackageReference Include="Castle.Core" Version="4.4.0" />
         <PackageReference Include="FluentAssertions" Version="5.9.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
-        <PackageReference Include="RDeF.Contracts" Version="1.0.0" />
-        <PackageReference Include="RDeF.Serialization" Version="1.0.0" />
+        <PackageReference Include="RDeF.Contracts" Version="1.1.0" />
+        <PackageReference Include="RDeF.Serialization" Version="1.1.0" />
         <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
     </ItemGroup>
 
@@ -45,8 +48,8 @@
         <PackageReference Include="Castle.Core" Version="4.4.0" />
         <PackageReference Include="FluentAssertions" Version="5.9.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
-        <PackageReference Include="RDeF.Contracts" Version="1.0.0" />
-        <PackageReference Include="RDeF.Serialization" Version="1.0.0" />
+        <PackageReference Include="RDeF.Contracts" Version="1.1.0" />
+        <PackageReference Include="RDeF.Serialization" Version="1.1.0" />
         <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
     </ItemGroup>
 
@@ -58,11 +61,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
-      <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
         <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      </PackageReference>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
     
     <ItemGroup>

--- a/Heracles.net.Tests/Server/api/documentation.jsonld
+++ b/Heracles.net.Tests/Server/api/documentation.jsonld
@@ -50,7 +50,13 @@
                         "range": ["http://www.w3.org/2001/XMLSchema#dateTime", "http://www.w3.org/2001/XMLSchema#date"]
                     }
                 }
-            ]
+            ],
+             "supportedOperation": [
+                 {
+                     "@type": ["hydra:Operation", "schema:DeleteAction"],
+                     "method": "DELETE"
+                 }
+             ]
         },
         {
             "@id": "schema:Person",

--- a/Heracles.net.Tests/Server/api/events/1.jsonld
+++ b/Heracles.net.Tests/Server/api/events/1.jsonld
@@ -1,0 +1,9 @@
+{
+    "@context": "/api/context.jsonld",
+    "@graph": [
+        {
+            "@id": "/api/events/1",
+            "@type": "schema:Event"
+        }
+    ]
+}

--- a/Heracles.net.Tests/Testing/IntegrationTest.cs
+++ b/Heracles.net.Tests/Testing/IntegrationTest.cs
@@ -31,7 +31,11 @@ namespace Heracles.Testing
         [SetUp]
         public async Task Setup()
         {
-            Client = ConfigureClient(HydraClientFactory.Configure().WithDefaults()).AndCreate();
+            var hydraClientFactory = HydraClientFactory
+                .Configure()
+                .WithDefaults()
+                .WithApiDocumentationsFetchedAndExtended();
+            Client = ConfigureClient(hydraClientFactory).AndCreate();
             ScenarioSetup();
             await TheTest();
         }

--- a/Heracles.net.Tests/Testing/Mappings.cs
+++ b/Heracles.net.Tests/Testing/Mappings.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Heracles.JsonLd;
+using Heracles.Namespaces;
+using Heracles.Rdf;
+using Heracles.Rdf.GraphTransformations;
+using Moq;
+using RDeF.Entities;
+using RDeF.Mapping;
+
+namespace Heracles.Testing
+{
+    public static class Mappings
+    {
+        public static void For<T>() where T : class
+        {
+            new JsonLdHypermediaProcessor(
+                new Mock<IOntologyProvider>().Object,
+                HttpCall,
+                new Mock<IGraphTransformer>().Object);
+        }
+
+        public static Mock<IEntityContext> InContextOf(Iri iri)
+        {
+            var @class = new Mock<IStatementMapping>(MockBehavior.Strict);
+            @class.SetupGet(_ => _.Term).Returns(iri);
+            var mapping = new Mock<IEntityMapping>(MockBehavior.Strict);
+            mapping.SetupGet(_ => _.Classes).Returns(new[] { @class.Object });
+            var mappings = new Mock<IMappingsRepository>(MockBehavior.Strict);
+            mappings.Setup(_ => _.FindEntityMappingFor(It.IsAny<IEntity>(), It.IsAny<Type>()))
+                .Returns(mapping.Object);
+            var context = new Mock<IEntityContext>(MockBehavior.Strict);
+            context.SetupGet(_ => _.Mappings).Returns(mappings.Object);
+            return context;
+        }
+
+        private static Task<IResponse> HttpCall(Uri url, IHttpOptions options, CancellationToken cancellationToken)
+        {
+            return Task.FromException<IResponse>(new NotImplementedException());
+        }
+    }
+}

--- a/Heracles.net.Tests/packages.config
+++ b/Heracles.net.Tests/packages.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Castle.Core" version="4.4.0" targetFramework="net471" />
-  <package id="FluentAssertions" version="5.7.0" targetFramework="net471" />
-  <package id="Moq" version="4.12.0" targetFramework="net471" />
-  <package id="NUnit" version="3.5.0" targetFramework="net45" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net471" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net471" />
-</packages>

--- a/Heracles.net/ApiDocumentationPolicy.cs
+++ b/Heracles.net/ApiDocumentationPolicy.cs
@@ -1,0 +1,21 @@
+namespace Heracles
+{
+    /// <summary>Defines API documentation discovery policies.</summary>
+    public enum ApiDocumentationPolicy
+    {
+        /// <summary>
+        /// Defines that no explicit calls for the API documentation should be invoked.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Defines that API documentation should be fetched only, leaving responses with original hypermedia controls.
+        /// </summary>
+        FetchOnly,
+        
+        /// <summary>
+        /// Defines that API documentation should be fetched and responses should be extended with additional details.
+        /// </summary>
+        FetchAndExtend
+    }
+}

--- a/Heracles.net/DataModel/HypermediaContainer.cs
+++ b/Heracles.net/DataModel/HypermediaContainer.cs
@@ -5,7 +5,10 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Heracles.Collections.Generic;
+using Heracles.Entities;
+using Heracles.Namespaces;
 using RDeF.Entities;
+using RollerCaster;
 
 namespace Heracles.DataModel
 {
@@ -32,7 +35,8 @@ namespace Heracles.DataModel
             Collections = hypermedia.DiscoverCollections();
             Operations = new HashSet<IOperation>();
             Links = new HashSet<IDereferencableLink>();
-            if (rootResource is IHydraResource hydraResource)
+            var hydraResource = rootResource.As<IHydraResource>(hydra.Resource);
+            if (hydraResource != null)
             {
                 Operations = hydraResource.Operations;
                 Links = hydraResource.Links;
@@ -43,7 +47,8 @@ namespace Heracles.DataModel
                 View = resourceView.View;
             }
 
-            if (rootResource is ICollection collection)
+            var collection = rootResource.As<ICollection>(hydra.Collection);
+            if (collection != null)
             {
                 Members = collection.Members;
                 TotalItems = collection.TotalItems;

--- a/Heracles.net/DataModel/IApiDocumentation.cs
+++ b/Heracles.net/DataModel/IApiDocumentation.cs
@@ -10,11 +10,11 @@ namespace Heracles.DataModel
     public interface IApiDocumentation : IHydraResource
     {
         /// <summary>Gets a title of this API documentation.</summary>
-        [Property("hydra", "title")]
+        [Property("hydra", "title", DefaultValue = "")]
         string Title { get; }
 
         /// <summary>Gets a description of this API documentation.</summary>
-        [Property("hydra", "description")]
+        [Property("hydra", "description", DefaultValue = "")]
         string Description { get; }
 
         /// <summary>Gets the supported classes by this API.</summary>

--- a/Heracles.net/DataModel/IClass.cs
+++ b/Heracles.net/DataModel/IClass.cs
@@ -7,12 +7,12 @@ namespace Heracles.DataModel
     [Class("hydra", "Class")]
     public interface IClass : IHydraResource
     {
-        /// <summary>Gets the class' display name.</summary>
-        [Property("hydra", "title")]
+        /// <summary>Gets the class' title.</summary>
+        [Property("hydra", "title", DefaultValue = "")]
         string Title { get; }
 
         /// <summary>Gets the class' description.</summary>
-        [Property("hydra", "description")]
+        [Property("hydra", "description", DefaultValue = "")]
         string Description { get; }
 
         /// <summary>Gets the class' supported operations. </summary>

--- a/Heracles.net/DataModel/ILink.cs
+++ b/Heracles.net/DataModel/ILink.cs
@@ -6,5 +6,12 @@ namespace Heracles.DataModel
     [Class("hydra", "Link")]
     public interface ILink : IDereferencableLink
     {
+        /// <summary>Gets the link's title.</summary>
+        [Property("hydra", "title", DefaultValue = "")]
+        string Title { get; }
+
+        /// <summary>Gets the link's description.</summary>
+        [Property("hydra", "description", DefaultValue = "")]
+        string Description { get; }
     }
 }

--- a/Heracles.net/DataModel/IOperation.cs
+++ b/Heracles.net/DataModel/IOperation.cs
@@ -7,8 +7,16 @@ namespace Heracles.DataModel
     [Class("hydra", "Operation")]
     public interface IOperation : IPointingResource
     {
+        /// <summary>Gets the operation's display name.</summary>
+        [Property("hydra", "title", DefaultValue = "")]
+        string Title { get; }
+
+        /// <summary>Gets the operation's description.</summary>
+        [Property("hydra", "description", DefaultValue = "")]
+        string Description { get; }
+        
         /// <summary>Gets a method to be used for the call.</summary>
-        [Property("hydra", "method")]
+        [Property("hydra", "method", DefaultValue = "GET")]
         string Method { get; }
 
         /// <summary>Gets the expected classes.</summary>

--- a/Heracles.net/DataModel/IProperty.cs
+++ b/Heracles.net/DataModel/IProperty.cs
@@ -7,14 +7,14 @@ namespace Heracles.DataModel
     [Class("hydra", "Property")]
     public interface IProperty : IResource
     {
-        /// <summary>Gets the property' display name.</summary>
-        [Property("hydra", "title")]
+        /// <summary>Gets the property' title.</summary>
+        [Property("hydra", "title", DefaultValue = "")]
         string Title { get; }
 
-        /// <summary>Gets the property's description.</summary>
-        [Property("hydra", "description")]
+        /// <summary>Gets the property' description.</summary>
+        [Property("hydra", "description", DefaultValue = "")]
         string Description { get; }
-
+        
         /// <summary>Gets the types of values this property can have.</summary>
         [Property("rdfs", "range")]
         ISet<IResource> ValuesOfType { get; }

--- a/Heracles.net/DataModel/ISupportedProperty.cs
+++ b/Heracles.net/DataModel/ISupportedProperty.cs
@@ -6,6 +6,14 @@ namespace Heracles.DataModel
     [Class("hydra", "SupportedProperty")]
     public interface ISupportedProperty : IHydraResource
     {
+        /// <summary>Gets the supported property's title.</summary>
+        [Property("hydra", "title", DefaultValue = "")]
+        string Title { get; }
+
+        /// <summary>Gets the supported property's description.</summary>
+        [Property("hydra", "description", DefaultValue = "")]
+        string Description { get; }
+
         /// <summary>Gets the actual property.</summary>
         [Property("hydra", "property")]
         IProperty Property { get; }

--- a/Heracles.net/DataModel/ResourceExtensions.cs
+++ b/Heracles.net/DataModel/ResourceExtensions.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Heracles.Namespaces;
 using RDeF.Entities;
 using RollerCaster;
+using RollerCaster.Reflection;
 
 namespace Heracles.DataModel
 {
@@ -15,12 +17,20 @@ namespace Heracles.DataModel
         internal static readonly PropertyInfo TargetPropertyInfo = typeof(IPointingResource).GetProperty(nameof(IPointingResource.Target));
         internal static readonly PropertyInfo MethodPropertyInfo = typeof(IOperation).GetProperty(nameof(IOperation.Method));
         internal static readonly PropertyInfo OriginatingMediaTypeProperty = typeof(IOperation).GetProperty(nameof(IOperation.OriginatingMediaType));
+        internal static readonly PropertyInfo LabelPropertyInfo = typeof(IResource).GetProperty(nameof(IResource.Label));
+        internal static readonly PropertyInfo CommentPropertyInfo = typeof(IResource).GetProperty(nameof(IResource.Comment));
+        internal static readonly PropertyInfo TitlePropertyInfo = typeof(IOperation).GetProperty(nameof(IOperation.Title));
+        internal static readonly PropertyInfo DescriptionPropertyInfo = typeof(IOperation).GetProperty(nameof(IOperation.Description));
+        internal static readonly HiddenPropertyInfo IriTemplatePropertyInfo = new HiddenPropertyInfo("IriTemplate", typeof(IIriTemplate), typeof(ITemplatedLink));
 
         private static readonly IDictionary<Iri, Func<IResource, string>> DisplayNameCandidates =
             new Dictionary<Iri, Func<IResource, string>>()
             {
                 { hydra.ApiDocumentation, _ => _.ActLike<IApiDocumentation>().Title },
+                { hydra.Operation, _ => _.ActLike<IOperation>().Title },
                 { hydra.Class, _ => _.ActLike<IClass>().Title },
+                { hydra.SupportedProperty, _ => _.ActLike<ISupportedProperty>().Title },
+                { hydra.Link, _ => _.ActLike<ILink>().Title },
                 { rdf.Property, _ => _.ActLike<IProperty>().Title },
                 { new Iri(), _ => _.Label }
             };
@@ -29,7 +39,10 @@ namespace Heracles.DataModel
             new Dictionary<Iri, Func<IResource, string>>()
             {
                 { hydra.ApiDocumentation, _ => _.ActLike<IApiDocumentation>().Description },
+                { hydra.Operation, _ => _.ActLike<IOperation>().Description },
                 { hydra.Class, _ => _.ActLike<IClass>().Description },
+                { hydra.SupportedProperty, _ => _.ActLike<ISupportedProperty>().Description },
+                { hydra.Link, _ => _.ActLike<ILink>().Description },
                 { rdf.Property, _ => _.ActLike<IProperty>().Description },
                 { new Iri(), _ => _.Comment }
             };
@@ -51,16 +64,19 @@ namespace Heracles.DataModel
             return resource.GetTextFor(TextDescriptionCandidates);
         }
 
-        internal static IOperation Copy(this IOperation source, Iri iri)
+        internal static IOperation Copy(this IOperation source, Iri iri, Uri baseUrl = null, IResource target = null)
         {
             var result = source.Context.Create<IOperation>(iri);
             var proxy = result.Unwrap();
-            proxy.SetProperty(MethodPropertyInfo, source.Method);
             result.Expects.CopyFrom(source.Expects);
             result.Returns.CopyFrom(source.Returns);
             result.ExpectedHeaders.CopyFrom(source.ExpectedHeaders);
             result.ReturnedHeaders.CopyFrom(source.ReturnedHeaders);
-            result.CopyFrom(source);
+            result.CopyFrom(source, baseUrl);
+            proxy.CopyFrom(TargetPropertyInfo, target ?? source.Target);
+            proxy.CopyFrom(MethodPropertyInfo, source.Method);
+            proxy.CopyFrom(TitlePropertyInfo, source.Title);
+            proxy.CopyFrom(DescriptionPropertyInfo, source.Description);
             return result;
         }
 
@@ -68,7 +84,7 @@ namespace Heracles.DataModel
         {
             var result = source.Context.Create<IDereferencableLink>(iri);
             var proxy = result.Unwrap();
-            proxy.SetProperty(RelationPropertyInfo, source.Iri.ToString());
+            proxy.CopyFrom(RelationPropertyInfo, source.Iri.ToString());
             result.SupportedOperations.CopyFrom(source.SupportedOperations);
             result.CopyFrom(source);
             return result;
@@ -77,26 +93,25 @@ namespace Heracles.DataModel
         private static string GetTextFor(this IResource resource, IDictionary<Iri, Func<IResource, string>> candidates)
         {
             string result = null;
-            foreach (var candidate in candidates)
+            foreach (var candidate in candidates.Where(_ => _.Key.IsBlank || resource.Is(_.Key)))
             {
-                if (candidate.Key.IsBlank || resource.Is(candidate.Key))
+                var candidateText = candidate.Value(resource);
+                if ((candidateText != null) && (result == null || candidateText.Length > result.Length))
                 {
-                    result = candidate.Value(resource);
-                    if (!String.IsNullOrEmpty(result))
-                    {
-                        break;
-                    }
+                    result = candidateText;
                 }
             }
 
             return result;
         }
 
-        private static void CopyFrom(this IPointingResource target, IPointingResource source)
+        private static void CopyFrom(this IPointingResource target, IPointingResource source, Uri baseUrl = null)
         {
             var proxy = target.Unwrap();
-            proxy.SetProperty(BaseUrlPropertyInfo, source.BaseUrl);
-            proxy.SetProperty(TargetPropertyInfo, source.Target);
+            proxy.CopyFrom(BaseUrlPropertyInfo, baseUrl ?? source.BaseUrl);
+            proxy.CopyFrom(TargetPropertyInfo, source.Target);
+            proxy.CopyFrom(LabelPropertyInfo, source.Label);
+            proxy.CopyFrom(CommentPropertyInfo, source.Comment);
             target.Collections.CopyFrom(source.Collections);
             target.Operations.CopyFrom(source.Operations);
             target.Links.CopyFrom(source.Links);
@@ -105,9 +120,20 @@ namespace Heracles.DataModel
 
         private static void CopyFrom<T>(this ICollection<T> targetCollection, IEnumerable<T> sourceCollection)
         {
-            foreach (var item in sourceCollection)
+            if (sourceCollection != null)
             {
-                targetCollection.Add(item);
+                foreach (var item in sourceCollection)
+                {
+                    targetCollection.Add(item);
+                }
+            }
+        }
+
+        private static void CopyFrom<T>(this MulticastObject proxy, PropertyInfo propertyInfo, T source)
+        {
+            if (source != null)
+            {
+                proxy.SetProperty(propertyInfo, source);
             }
         }
     }

--- a/Heracles.net/DataModel/TemplatedResource.cs
+++ b/Heracles.net/DataModel/TemplatedResource.cs
@@ -15,9 +15,6 @@ namespace Heracles.DataModel
     /// <typeparam name="T">Type of the resource described.</typeparam>
     public static class TemplatedResource<T> where T : IPointingResource
     {
-        private static readonly PropertyInfo TargetPropertyInfo = typeof(IPointingResource).GetProperty(nameof(IPointingResource.Target));
-        private static readonly PropertyInfo BaseUrlPropertyInfo = typeof(IPointingResource).GetProperty(nameof(IPointingResource.BaseUrl));
-
         /// <summary>Expands an URI template with given variables.</summary>
         /// <param name="pointingResource">Pointing resource.</param>
         /// <param name="mappedVariables">Template variables with value.</param>
@@ -25,12 +22,12 @@ namespace Heracles.DataModel
         /// <returns>Expanded templated resource.</returns>
         public static T ExpandTarget(IPointingResource pointingResource, IDictionary<string, string> mappedVariables, Iri iri)
         {
-            var iriTemplate = (IIriTemplate)pointingResource.Unwrap().GetProperty(JsonLdHypermediaProcessor.IriTemplatePropertyInfo);
+            var iriTemplate = (IIriTemplate)pointingResource.Unwrap().GetProperty(ResourceExtensions.IriTemplatePropertyInfo);
             var targetUri = new Uri(pointingResource.BaseUrl, new UriTemplate(iriTemplate.Template).AddParameters(mappedVariables).Resolve());
             var result = pointingResource.Context.Create<T>(iri);
             var proxy = result.Unwrap();
-            proxy.SetProperty(TargetPropertyInfo, pointingResource.Context.Create<IResource>(targetUri));
-            proxy.SetProperty(BaseUrlPropertyInfo, pointingResource.BaseUrl);
+            proxy.SetProperty(ResourceExtensions.TargetPropertyInfo, pointingResource.Context.Create<IResource>(targetUri));
+            proxy.SetProperty(ResourceExtensions.BaseUrlPropertyInfo, pointingResource.BaseUrl);
             result.Type.AddRange(pointingResource.Type.Where(_ => _ != hydra.IriTemplate));
             result.Collections.AddRange(pointingResource.Collections);
             result.Links.AddRange(pointingResource.Links);
@@ -45,7 +42,7 @@ namespace Heracles.DataModel
         /// <returns>Expanded templated resource.</returns>
         public static T ExpandTarget(IPointingResource pointingResource, Action<MappingsBuilder> mappedVariables, Iri iri)
         {
-            var iriTemplate = (IIriTemplate)pointingResource.Unwrap().GetProperty(JsonLdHypermediaProcessor.IriTemplatePropertyInfo);
+            var iriTemplate = (IIriTemplate)pointingResource.Unwrap().GetProperty(ResourceExtensions.IriTemplatePropertyInfo);
             var builder = new MappingsBuilder(iriTemplate.Mappings);
             mappedVariables(builder);
             return ExpandTarget(pointingResource, builder.Complete(), iri);

--- a/Heracles.net/Entities/EntityExtensions.cs
+++ b/Heracles.net/Entities/EntityExtensions.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Heracles.Namespaces;
 using RDeF.Entities;
+using RollerCaster;
 
 namespace Heracles.Entities
 {
@@ -75,6 +76,18 @@ namespace Heracles.Entities
             }
 
             return result;
+        }
+
+        internal static TEntity As<TEntity>(this IEntity entity, Iri type) where TEntity : class, IEntity
+        {
+            TEntity result;
+            if ((result = entity as TEntity) != null
+                || (entity.Is(type) && (result = entity.ActLike<TEntity>()) != null))
+            {
+                return result;
+            }
+
+            return null;
         }
     }
 }

--- a/Heracles.net/Heracles.net.csproj
+++ b/Heracles.net/Heracles.net.csproj
@@ -8,38 +8,46 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net461|AnyCPU'">
-      <DocumentationFile>.\bin\Heracles.net.xml</DocumentationFile>
+        <DocumentationFile>.\bin\Heracles.net.xml</DocumentationFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+        <DocumentationFile>bin\Debug\Heracles.net.xml</DocumentationFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DocumentationFile>bin\Release\Heracles.net.xml</DocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>
-      <None Remove="JsonLd\hydra.json" />
+        <None Remove="JsonLd\hydra.json" />
     </ItemGroup>
 
     <ItemGroup>
-      <Compile Include="..\.build\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
-      <Compile Include="..\.build\VersionAssemblyInfo.cs" Link="Properties\VersionAssemblyInfo.cs" />
+        <Compile Include="..\.build\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+        <Compile Include="..\.build\VersionAssemblyInfo.cs" Link="Properties\VersionAssemblyInfo.cs" />
     </ItemGroup>
 
     <ItemGroup>
-      <EmbeddedResource Include="JsonLd\hydra.json" />
+        <EmbeddedResource Include="JsonLd\hydra.json" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-        <PackageReference Include="RDeF.Contracts" Version="1.0.0" />
-        <PackageReference Include="RDeF.Core" Version="1.0.0" />
-        <PackageReference Include="RDeF.Mapping.Attributes" Version="1.0.0" />
-        <PackageReference Include="RDeF.Serialization" Version="1.0.0" />
+        <PackageReference Include="RDeF.Contracts" Version="1.1.0" />
+        <PackageReference Include="RDeF.Core" Version="1.1.0" />
+        <PackageReference Include="RDeF.Mapping.Attributes" Version="1.1.0" />
+        <PackageReference Include="RDeF.Serialization" Version="1.1.0" />
         <PackageReference Include="RollerCaster" Version="1.3.0" />
         <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
         <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-        <PackageReference Include="RDeF.Contracts" Version="1.0.0" />
-        <PackageReference Include="RDeF.Core" Version="1.0.0" />
-        <PackageReference Include="RDeF.Mapping.Attributes" Version="1.0.0" />
-        <PackageReference Include="RDeF.Serialization" Version="1.0.0" />
+        <PackageReference Include="RDeF.Contracts" Version="1.1.0" />
+        <PackageReference Include="RDeF.Core" Version="1.1.0" />
+        <PackageReference Include="RDeF.Mapping.Attributes" Version="1.1.0" />
+        <PackageReference Include="RDeF.Serialization" Version="1.1.0" />
         <PackageReference Include="RollerCaster" Version="1.3.0" />
         <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
     </ItemGroup>
@@ -52,11 +60,11 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
-      <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
         <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      </PackageReference>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/Heracles.net/HypermediaProcessingOptions.cs
+++ b/Heracles.net/HypermediaProcessingOptions.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using Heracles.DataModel;
 
 namespace Heracles
 {
@@ -6,13 +9,19 @@ namespace Heracles
     public class HypermediaProcessingOptions : IHypermediaProcessingOptions
     {
         private readonly LinksPolicy? _linksPolicy;
-        
+        private readonly ApiDocumentationPolicy? _apiDocumentationPolicy;
+
         /// <summary>Initializes a new instance of the <see cref="HypermediaProcessingOptions" /> class.</summary>
         /// <param name="originalUrl">Original Url.</param>
         /// <param name="linksPolicy">Links policy.</param>
+        /// <param name="apiDocumentationPolicy">API documentation policy.</param>
+        /// <param name="apiDocumentations">API documentations.</param>
         public HypermediaProcessingOptions(
             Uri originalUrl = null,
-            LinksPolicy linksPolicy = LinksPolicy.Strict) : this(null, null, originalUrl, linksPolicy)
+            LinksPolicy linksPolicy = LinksPolicy.Strict,
+            ApiDocumentationPolicy apiDocumentationPolicy = ApiDocumentationPolicy.None,
+            IEnumerable<IApiDocumentation> apiDocumentations = null)
+            : this(null, null, originalUrl, linksPolicy, apiDocumentationPolicy, apiDocumentations)
         {
         }
 
@@ -21,14 +30,20 @@ namespace Heracles
         /// <param name="auxiliaryOriginalUrl">Original url of the <paramref name="auxiliaryResponse"/>.</param>
         /// <param name="originalUrl">Original Url.</param>
         /// <param name="linksPolicy">Links policy.</param>
-        public HypermediaProcessingOptions(
+        /// <param name="apiDocumentationPolicy">API documentation policy.</param>
+        /// <param name="apiDocumentations">API documentations.</param>
+        internal HypermediaProcessingOptions(
             IResponse auxiliaryResponse = null,
             Uri auxiliaryOriginalUrl = null,
             Uri originalUrl = null,
-            LinksPolicy? linksPolicy = null)
+            LinksPolicy? linksPolicy = null,
+            ApiDocumentationPolicy? apiDocumentationPolicy = null,
+            IEnumerable<IApiDocumentation> apiDocumentations = null)
         {
             OriginalUrl = originalUrl;
             _linksPolicy = linksPolicy;
+            _apiDocumentationPolicy = apiDocumentationPolicy;
+            ApiDocumentations = apiDocumentations ?? Array.Empty<IApiDocumentation>();
             AuxiliaryResponse = auxiliaryResponse;
             AuxiliaryOriginalUrl = auxiliaryOriginalUrl;
         }
@@ -36,8 +51,17 @@ namespace Heracles
         /// <inheritdoc />
         public LinksPolicy LinksPolicy
         {
-            get { return _linksPolicy ?? LinksPolicy.Strict; }
+            get { return _linksPolicy ?? Heracles.LinksPolicy.Strict; }
         }
+
+        /// <inheritdoc />
+        public ApiDocumentationPolicy ApiDocumentationPolicy
+        {
+            get { return _apiDocumentationPolicy ?? ApiDocumentationPolicy.None; }
+        }
+        
+        /// <inheritdoc />
+        public IEnumerable<IApiDocumentation> ApiDocumentations { get; }
         
         /// <inheritdoc />
         public Uri OriginalUrl { get; }
@@ -53,11 +77,30 @@ namespace Heracles
         /// <returns>Merged options where values are taken first from this instance.</returns>
         public HypermediaProcessingOptions MergeWith(IHypermediaProcessingOptions options)
         {
+            var apiDocumentations = new List<IApiDocumentation>();
+            foreach (var apiDocumentation in ApiDocumentations)
+            {
+                apiDocumentations.Add(apiDocumentation);
+            }
+
+            if (options != null)
+            {
+                foreach (var apiDocumentation in options.ApiDocumentations)
+                {
+                    if (apiDocumentations.All(_ => _.Iri != apiDocumentation.Iri))
+                    {
+                        apiDocumentations.Add(apiDocumentation);
+                    }
+                }
+            }
+
             return new HypermediaProcessingOptions(
                 AuxiliaryResponse ?? options?.AuxiliaryResponse,
                 AuxiliaryOriginalUrl ?? options?.AuxiliaryOriginalUrl,
                 OriginalUrl ?? options?.OriginalUrl,
-                _linksPolicy ?? options?.LinksPolicy);
+                _linksPolicy ?? options?.LinksPolicy,
+                _apiDocumentationPolicy ?? options?.ApiDocumentationPolicy,
+                apiDocumentations);
         }
     }
 }

--- a/Heracles.net/IHydraClientFactory.cs
+++ b/Heracles.net/IHydraClientFactory.cs
@@ -10,6 +10,9 @@ namespace Heracles
 
         /// <summary>Gets a currently configured <see cref="LinksPolicy" />.</summary>
         LinksPolicy CurrentLinksPolicy { get; }
+        
+        /// <summary>Gets a currently configured <see cref="ApiDocumentationPolicy" />.</summary>
+        ApiDocumentationPolicy CurrentApiDocumentationPolicy { get; }
 
         /// <summary>Gets an ontology provider.</summary>
         IOntologyProvider OntologyProvider { get; }

--- a/Heracles.net/IHypermediaProcessingOptions.cs
+++ b/Heracles.net/IHypermediaProcessingOptions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using Heracles.DataModel;
 
 namespace Heracles
 {
@@ -7,6 +9,12 @@ namespace Heracles
     {
         /// <summary>Gets a policy defining which related resources will be added to links collection.</summary>
         LinksPolicy LinksPolicy { get; }
+        
+        /// <summary>Gets a policy defining how API documentations should be handled when obtaining resources.</summary>
+        ApiDocumentationPolicy ApiDocumentationPolicy { get; }
+        
+        /// <summary>Gets an API documentations obtained.</summary>
+        IEnumerable<IApiDocumentation> ApiDocumentations { get; }
 
         /// <summary>
         /// Gets an originally requested Url.

--- a/Heracles.net/IResourceCache.cs
+++ b/Heracles.net/IResourceCache.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using Heracles.DataModel;
+
+namespace Heracles
+{
+    /// <summary>Provides an abstraction over a cache that stores resources.</summary>
+    public interface IResourceCache
+    {
+        /// <summary>Gets or sets a resource within the cache.</summary>
+        /// <param name="uri">Uri of the resource.</param>
+        IResource this[Uri uri] { get; set; }
+
+        /// <summary>Gets all cached resources of type <typeparamref name="T" />.</summary>
+        /// <typeparam name="T">Type of resources to obtain from cache.</typeparam>
+        /// <returns>Collection of cached resources.</returns>
+        IEnumerable<T> All<T>() where T : IResource;
+    }
+}

--- a/Heracles.net/JsonLd/JsonLdHypermediaProcessor.cs
+++ b/Heracles.net/JsonLd/JsonLdHypermediaProcessor.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Heracles.DataModel;
 using Heracles.Rdf;
+using Heracles.Rdf.GraphTransformations;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using RDeF.Serialization;
@@ -38,8 +39,12 @@ namespace Heracles.JsonLd
         /// <summary>Initializes a new instance of the <see cref="JsonLdHypermediaProcessor" /> class.</summary>
         /// <param name="ontologyProvider">Ontology provider.</param>
         /// <param name="httpCall">HTTP call facility.</param>
-        public JsonLdHypermediaProcessor(IOntologyProvider ontologyProvider, HttpCallFacility httpCall)
-            : base(ontologyProvider, httpCall)
+        /// <param name="graphTransformer">Graph transformation facility.</param>
+        public JsonLdHypermediaProcessor(
+            IOntologyProvider ontologyProvider,
+            HttpCallFacility httpCall,
+            IGraphTransformer graphTransformer)
+            : base(ontologyProvider, httpCall, graphTransformer)
         {
         }
 

--- a/Heracles.net/N3/N3HypermediaProcessor.cs
+++ b/Heracles.net/N3/N3HypermediaProcessor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Heracles.Rdf;
+using Heracles.Rdf.GraphTransformations;
 using RDeF.Serialization;
 
 namespace Heracles.N3
@@ -19,8 +20,12 @@ namespace Heracles.N3
         /// <summary>Initializes a new instance of the <see cref="N3HypermediaProcessor" /> class.</summary>
         /// <param name="ontologyProvider">Ontology provider.</param>
         /// <param name="httpCall">HTTP call facility.</param>
-        public N3HypermediaProcessor(IOntologyProvider ontologyProvider, HttpCallFacility httpCall)
-            : base(ontologyProvider, httpCall)
+        /// <param name="graphTransformer">Graph transformation facility.</param>
+        public N3HypermediaProcessor(
+            IOntologyProvider ontologyProvider,
+            HttpCallFacility httpCall,
+            IGraphTransformer graphTransformer)
+            : base(ontologyProvider, httpCall, graphTransformer)
         {
         }
 

--- a/Heracles.net/N3/N3HypermediaProcessorFactory.cs
+++ b/Heracles.net/N3/N3HypermediaProcessorFactory.cs
@@ -1,4 +1,6 @@
-﻿namespace Heracles.N3
+﻿using Heracles.Rdf.GraphTransformations;
+
+namespace Heracles.N3
 {
     /// <summary>Provides a factory method to be registered with Hydra client factory.</summary>
     public class N3HypermediaProcessorFactory
@@ -8,7 +10,8 @@
         /// <returns>Instance of the <see cref="N3HypermediaProcessor" /> class.</returns>
         public static IHypermediaProcessor Instance(IHydraClientFactory context)
         {
-            return new N3HypermediaProcessor(context.OntologyProvider, context.CurrentHttpCall);
+            var graphTransformer = new CompoundGraphTransformer(new[] { new EntryPointCorrectingGraphTransformer() });
+            return new N3HypermediaProcessor(context.OntologyProvider, context.CurrentHttpCall, graphTransformer);
         }
     }
 }

--- a/Heracles.net/Net/HttpResponse.cs
+++ b/Heracles.net/Net/HttpResponse.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -10,6 +11,8 @@ using Heracles.DataModel;
 namespace Heracles.Net
 {
     /// <summary>Provides a default implementation of the <see cref="IResponse" />.</summary>
+    [SuppressMessage("TS0000", "NoUnitTests", Justification = "Strictly bound to physical layer. Unable to unit test.")]
+    [ExcludeFromCodeCoverage]
     public class HttpResponse : IResponse
     {
         private readonly HttpWebResponse _response;

--- a/Heracles.net/Net/HttpWebRequestHttpCallFacility.cs
+++ b/Heracles.net/Net/HttpWebRequestHttpCallFacility.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,6 +8,8 @@ namespace Heracles.Net
 {
     internal class HttpWebRequestHttpCallFacility
     {
+        [SuppressMessage("TS0000", "NoUnitTests", Justification = "Strictly bound to physical layer. Unable to unit test.")]
+        [ExcludeFromCodeCoverage]
         public async Task<IResponse> Call(Uri url, IHttpOptions options, CancellationToken cancellationToken)
         {
             var request = WebRequest.Create(url);

--- a/Heracles.net/Rdf/GraphTransformations/ApiDocumentationExtendingGraphTransformer.cs
+++ b/Heracles.net/Rdf/GraphTransformations/ApiDocumentationExtendingGraphTransformer.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Linq;
+using Heracles.DataModel;
+using RDeF.Entities;
+using RollerCaster;
+
+namespace Heracles.Rdf.GraphTransformations
+{
+    /// <summary>Extends resources with <see cref="IApiDocumentation" />'s discovered capabilities.</summary>
+    public class ApiDocumentationExtendingGraphTransformer : IGraphTransformer
+    {
+        /// <inheritdoc />
+        public IEnumerable<ITypedEntity> Transform(
+            IEnumerable<ITypedEntity> resources,
+            IHypermediaProcessor processor,
+            IHypermediaProcessingOptions options = null)
+        {
+            if (options != null && options.ApiDocumentations.Any())
+            {
+                foreach (var resource in resources)
+                {
+                    var validSupportedClasses =
+                        from apiDocumentation in options.ApiDocumentations
+                        from supportedClass in apiDocumentation.SupportedClasses
+                        where resource.Is(supportedClass.Iri)
+                        select supportedClass;
+                    IHydraResource dereferencableResource = null;
+                    foreach (var supportedClass in validSupportedClasses)
+                    {
+                        dereferencableResource = dereferencableResource ?? resource.AssertAs<IHydraResource>();
+                        foreach (var operation in supportedClass.SupportedOperations)
+                        {
+                            dereferencableResource.Operations.Add(
+                                operation.Copy(new Iri(), options.OriginalUrl, dereferencableResource));
+                        }
+                    }
+                }
+            }
+
+            return resources;
+        }
+    }
+}

--- a/Heracles.net/Rdf/GraphTransformations/CompoundGraphTransformer.cs
+++ b/Heracles.net/Rdf/GraphTransformations/CompoundGraphTransformer.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using RDeF.Entities;
+
+namespace Heracles.Rdf.GraphTransformations
+{
+    /// <summary>Provides a collective wrapper over multiple <see cref="IGraphTransformer" />s.</summary>
+    public class CompoundGraphTransformer : IGraphTransformer
+    {
+        private readonly IEnumerable<IGraphTransformer> _graphTransformers;
+
+        /// <summary>Initializes a new instance of the <see cref="CompoundGraphTransformer" /> class.</summary>
+        /// <param name="graphTransformers">Other graph transforming facilities to use.</param>
+        public CompoundGraphTransformer(IEnumerable<IGraphTransformer> graphTransformers)
+        {
+            _graphTransformers = graphTransformers ?? throw new ArgumentNullException(nameof(graphTransformers));
+        }
+        
+        /// <inheritdoc />
+        public IEnumerable<ITypedEntity> Transform(
+            IEnumerable<ITypedEntity> resources,
+            IHypermediaProcessor processor,
+            IHypermediaProcessingOptions options = null)
+        {
+            var result = resources;
+            foreach (var graphTransformer in _graphTransformers)
+            {
+                result = graphTransformer.Transform(result, processor, options);
+            }
+
+            return result;
+        }
+    }
+}

--- a/Heracles.net/Rdf/GraphTransformations/EntryPointCorrectingGraphTransformer.cs
+++ b/Heracles.net/Rdf/GraphTransformations/EntryPointCorrectingGraphTransformer.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Heracles.DataModel;
+using Heracles.Namespaces;
+using RDeF.Entities;
+using RollerCaster;
+
+namespace Heracles.Rdf.GraphTransformations
+{
+    /// <summary>Tries to correct missing entry point in hydra:ApiDocumentation resource.</summary>
+    public class EntryPointCorrectingGraphTransformer : IGraphTransformer
+    {
+        private static readonly PropertyInfo EntryPointPropertyInfo =
+            typeof(IApiDocumentation).GetProperty(nameof(IApiDocumentation.EntryPoint));
+        
+        /// <inheritdoc />
+        public IEnumerable<ITypedEntity> Transform(
+            IEnumerable<ITypedEntity> resources, 
+            IHypermediaProcessor processor,
+            IHypermediaProcessingOptions options = null)
+        {
+            var apiDocumentation = resources?.FirstOrDefault(_ => _.Is(hydra.ApiDocumentation))?.ActLike<IApiDocumentation>();
+            if (apiDocumentation != null
+                && apiDocumentation.EntryPoint == null
+                && options != null
+                && processor.Supports(options.AuxiliaryResponse) != Level.None
+                && Regex.IsMatch(options.AuxiliaryOriginalUrl.ToString(), ".+://[^/]+/?"))
+            {
+                var entryPoint = apiDocumentation.Context.Create<IResource>(options.AuxiliaryOriginalUrl);
+                var proxy = apiDocumentation.Unwrap();
+                proxy.SetProperty(EntryPointPropertyInfo, entryPoint);
+            }
+
+            return resources;
+        }
+    }
+}

--- a/Heracles.net/Rdf/GraphTransformations/IGraphTransformer.cs
+++ b/Heracles.net/Rdf/GraphTransformations/IGraphTransformer.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using RDeF.Entities;
+
+namespace Heracles.Rdf.GraphTransformations
+{
+    /// <summary>Describes an abstract resource transforming facility.</summary>
+    public interface IGraphTransformer
+    {
+        /// <summary>Tranforms given resources.</summary>
+        /// <param name="resources">Resources to be transformed.</param>
+        /// <param name="processor">Hypermedia processor requesting a resource transformation.</param>
+        /// <param name="options">Additional processing options.</param>
+        /// <returns>Transformed resources.</returns>
+        IEnumerable<ITypedEntity> Transform(
+            IEnumerable<ITypedEntity> resources,
+            IHypermediaProcessor processor,
+            IHypermediaProcessingOptions options = null);
+    }
+}

--- a/Heracles.net/Rdf/HypermediaProcessorBase.ResourceInitializer.cs
+++ b/Heracles.net/Rdf/HypermediaProcessorBase.ResourceInitializer.cs
@@ -176,8 +176,8 @@ namespace Heracles.Rdf
             result.Type.Remove(type == hydra.TemplatedLink ? hydra.Link : hydra.TemplatedLink);
             if (type == hydra.TemplatedLink && @object != null)
             {
-                var templatedLink = result.ActLike<ITemplatedLink>();
-                proxy.SetProperty(IriTemplatePropertyInfo, @object.ActLike<IIriTemplate>());
+                var templatedLink = result.AssertAs<ITemplatedLink>();
+                proxy.SetProperty(ResourceExtensions.IriTemplatePropertyInfo, @object.AssertAs<IIriTemplate>());
                 result = templatedLink;
             }
 
@@ -196,9 +196,9 @@ namespace Heracles.Rdf
                 var result = operation.Copy(GetNextIri("Operation"));
                 result.Type.AddIfNotExist(type);
                 result.Type.AddIfNotExist(hydra.IriTemplate);
-                var templatedOperation = result.ActLike<ITemplatedOperation>();
+                var templatedOperation = result.AssertAs<ITemplatedOperation>();
                 var proxy = templatedOperation.Unwrap();
-                proxy.SetProperty(IriTemplatePropertyInfo, @object.ActLike<IIriTemplate>());
+                proxy.SetProperty(ResourceExtensions.IriTemplatePropertyInfo, @object.AssertAs<IIriTemplate>());
                 result = templatedOperation;
                 owner.Operations.Add(result);
                 yield return result;

--- a/Heracles.net/Rdf/ProcessingState.cs
+++ b/Heracles.net/Rdf/ProcessingState.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Heracles.DataModel;
 using Heracles.Entities;
 using Heracles.Namespaces;
 using RDeF.Entities;
@@ -16,7 +17,7 @@ namespace Heracles.Rdf
             IEntityContext context,
             IOntologyProvider ontologyProvider,
             Iri rootResource,
-            LinksPolicy linksPolicy,
+            IHypermediaProcessingOptions options,
             string originatingMediaType)
         {
             _ontologyProvider = ontologyProvider;
@@ -27,15 +28,24 @@ namespace Heracles.Rdf
             AllHypermedia = new HashSet<Iri>();
             BaseUrl = rootResource;
             Root = rootResource.ToRoot();
-            LinksPolicy = linksPolicy;
             OriginatingMediaType = originatingMediaType;
+            if (options != null)
+            {
+                LinksPolicy = options.LinksPolicy;
+                ApiDocumentationPolicy = options.ApiDocumentationPolicy;
+                ApiDocumentations = options.ApiDocumentations;
+            }
         }
 
         internal event EventHandler<EventArgs> ProcessingCompleted;
 
         internal IEntityContext Context { get; }
 
-        internal LinksPolicy LinksPolicy { get; }
+        internal LinksPolicy LinksPolicy { get; } = LinksPolicy.Strict;
+
+        internal ApiDocumentationPolicy ApiDocumentationPolicy { get; } = ApiDocumentationPolicy.None;
+
+        internal IEnumerable<IApiDocumentation> ApiDocumentations { get; } = Array.Empty<IApiDocumentation>();
 
         internal Iri BaseUrl { get; }
 

--- a/Heracles.net/SimpleVolatileResourceCache.cs
+++ b/Heracles.net/SimpleVolatileResourceCache.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Heracles.DataModel;
+
+namespace Heracles
+{
+    /// <summary>
+    /// Provides a simple, <see cref="ConcurrentDictionary{TKey,TValue}" /> based implementation
+    /// of the <see cref="IResourceCache" /> interface.
+    /// </summary>
+    public class SimpleVolatileResourceCache : IResourceCache
+    {
+        private readonly ConcurrentDictionary<Uri, IResource> _cache = new ConcurrentDictionary<Uri, IResource>();
+        
+        /// <inheritdoc />
+        public IResource this[Uri uri]
+        {
+            get { return _cache.TryGetValue(uri, out IResource result) ? result : null; }
+            set { _cache[uri] = value; }
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<T> All<T>() where T : IResource
+        {
+            return _cache.Values.OfType<T>();
+        }
+    }
+}


### PR DESCRIPTION
Added feature that allows the client to fetch the API documentation with a given resource and then expand obtained resource's operations with the supported ones described in the API documentation.